### PR TITLE
Add build dependency on rti-connext-dds-5.3.1

### DIFF
--- a/connext_cmake_module/package.xml
+++ b/connext_cmake_module/package.xml
@@ -6,6 +6,8 @@
   <description>Provide CMake module to find RTI Connext.</description>
   <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
   <license>Apache License 2.0</license>
+  
+  <build_depend>rti-connext-dds-5.3.1</build_depend>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/connext_cmake_module/package.xml
+++ b/connext_cmake_module/package.xml
@@ -6,12 +6,12 @@
   <description>Provide CMake module to find RTI Connext.</description>
   <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
   <license>Apache License 2.0</license>
-  
-  <build_depend>rti-connext-dds-5.3.1</build_depend>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <buildtool_export_depend>ament_cmake</buildtool_export_depend>
+  
+  <build_depend>rti-connext-dds-5.3.1</build_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
The RTI Connext package is required by this package in order to properly set up the environment hooks for downstream packages.