### PR TITLE
Re-export NDDSHOME variable in environment hook.

### DIFF
--- a/connext_cmake_module/env_hook/connext.bat.in
+++ b/connext_cmake_module/env_hook/connext.bat.in
@@ -38,6 +38,8 @@ if not exist "%_Connext_ENV_SETUP_SCRIPT%" (
 :: Call RTI's env setup script, piping stdout to nul, since they have echo on.
 call "%_Connext_ENV_SETUP_SCRIPT%" 1> nul
 
+set "NDDSHOME=%_NDDSHOME_TO_USE%"
+
 set "_Connext_ENV_SETUP_SCRIPT="
 set "_BUILDTIME_NDDSHOME="
 set "_NDDSHOME_TO_USE="

--- a/connext_cmake_module/env_hook/connext.sh.in
+++ b/connext_cmake_module/env_hook/connext.sh.in
@@ -66,6 +66,8 @@ else
 fi
 unset _IS_DARWIN
 
+export NDDSHOME="$_NDDSHOME_TO_USE"
+
 unset _Connext_LIBRARY_DIR_TO_USE
 unset _NDDSHOME_TO_USE
 unset _BUILDTIME_NDDSHOME


### PR DESCRIPTION
The `find_package(Connext)` function provided by connext_cmake_module relies on the NDDSHOME variable being set.

In order for the connext_cmake_module package to be the only one which needs to source the RTI environment script on the buildfarm the environment hook must re-export it.

The implementation was inspired by https://github.com/ros2/rmw_opensplice/pull/233 but I noticed that the Batch file hook sources the upstream connext script internally which would presumably set the NDDSHOME variable. So the change to the Batch hook in this commit may not be needed.