### PR TITLE
avoid using undefined var

### DIFF
--- a/rosidl_typesupport_connext_c/CMakeLists.txt
+++ b/rosidl_typesupport_connext_c/CMakeLists.txt
@@ -2,8 +2,13 @@ cmake_minimum_required(VERSION 3.5)
 
 project(rosidl_typesupport_connext_c)
 
-set(CONNEXT_STATIC_DISABLE $ENV{CONNEXT_STATIC_DISABLE}
-  CACHE BOOL "If Connext Static should be disabled.")
+if(DEFINED ENV{CONNEXT_STATIC_DISABLE})
+  set(CONNEXT_STATIC_DISABLE $ENV{CONNEXT_STATIC_DISABLE}
+    CACHE BOOL "If Connext Static should be disabled.")
+else()
+  set(CONNEXT_STATIC_DISABLE FALSE
+    CACHE BOOL "If Connext Static should be disabled.")
+endif()
 
 # Default to C99
 if(NOT CMAKE_C_STANDARD)


### PR DESCRIPTION
Follow-up of #9 for the c typesupport

Linux build just to make sure it still builds [![Build Status](https://ci.ros2.org/job/ci_linux/5027/badge/icon)](https://ci.ros2.org/job/ci_linux/5027/)