### PR TITLE
Export dependency on rcutils instead of requiring it.

### DIFF
--- a/rosidl_typesupport_connext_c/CMakeLists.txt
+++ b/rosidl_typesupport_connext_c/CMakeLists.txt
@@ -44,6 +44,7 @@ endif()
 find_package(ament_cmake_python REQUIRED)
 find_package(rosidl_typesupport_connext_cpp REQUIRED)
 
+ament_export_dependencies(rcutils)
 ament_export_dependencies(rmw)
 ament_export_dependencies(rosidl_cmake)
 ament_export_dependencies(rosidl_generator_c)

--- a/rosidl_typesupport_connext_c/package.xml
+++ b/rosidl_typesupport_connext_c/package.xml
@@ -15,6 +15,7 @@
 
   <buildtool_export_depend>ament_cmake</buildtool_export_depend>
   <buildtool_export_depend>connext_cmake_module</buildtool_export_depend>
+  <buildtool_export_depend>rcutils</buildtool_export_depend>
   <buildtool_export_depend>rosidl_cmake</buildtool_export_depend>
   <buildtool_export_depend>rosidl_generator_c</buildtool_export_depend>
   <buildtool_export_depend>rosidl_generator_dds_idl</buildtool_export_depend>

--- a/rosidl_typesupport_connext_cpp/CMakeLists.txt
+++ b/rosidl_typesupport_connext_cpp/CMakeLists.txt
@@ -20,7 +20,6 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(ament_cmake REQUIRED)
-find_package(rcutils REQUIRED)
 
 find_package(connext_cmake_module REQUIRED)
 find_package(Connext QUIET MODULE)

--- a/rosidl_typesupport_connext_cpp/CMakeLists.txt
+++ b/rosidl_typesupport_connext_cpp/CMakeLists.txt
@@ -38,6 +38,7 @@ endif()
 
 find_package(ament_cmake_python REQUIRED)
 
+ament_export_dependencies(rcutils)
 ament_export_dependencies(rmw)
 ament_export_dependencies(rosidl_cmake)
 ament_export_dependencies(rosidl_generator_c)


### PR DESCRIPTION
This is causing build failures in Crystal, see http://build.ros2.org/view/Cbin_uB64/job/Cbin_uB64__rosidl_typesupport_connext_cpp__ubuntu_bionic_amd64__binary/8/

In #16, rcutils was introduced as a buildtool_export_depend since generated code makes use of an rcutils-provided type. However, as far as I can tell the build of rosidl_typesupport_connext_cpp itself doesn't use rcutils, so the CMakeLists.txt need not require it. This does raise the question of whether downstream packages need to have cmake logic injected so they correctly require rcutils.


 I also wonder about the use of `buildtool_export_depend`. [per the specification](http://www.ros.org/reps/rep-0140.html#buildtool-export-depend-multiple) this suggests that rcutils should be required in the _host_ environment of any package built on this one. But looking at how it's used, it would seem to me like [build_export_depend](http://www.ros.org/reps/rep-0140.html#build-export-depend-multiple) is what we actually want since that requires rcutils on the _target_ system.

The dependency semantic is long term concern not an immediate one since there are no cross-compilation scenarios in the official builds, but it's still something I could use guidance on, if only for my own edification.