### PR TITLE
Removed Connext as target dependency, this library doesn't need to li…

### DIFF
--- a/rosidl_typesupport_connext_c/CMakeLists.txt
+++ b/rosidl_typesupport_connext_c/CMakeLists.txt
@@ -62,7 +62,6 @@ endif()
 target_include_directories(${PROJECT_NAME} PUBLIC include)
 ament_target_dependencies(
   ${PROJECT_NAME}
-  "Connext"
   "rosidl_typesupport_connext_cpp")
 ament_export_libraries(${PROJECT_NAME})
 


### PR DESCRIPTION
…nk with the RTI provided libraries

    * rosidl_typesupport_connext_c/CMakeLists.txt: