### PR TITLE
Add cpplint flag to ignore long functions in generated code

### DIFF
--- a/rosidl_typesupport_connext_c/cmake/rosidl_typesupport_connext_c_generate_interfaces.cmake
+++ b/rosidl_typesupport_connext_c/cmake/rosidl_typesupport_connext_c_generate_interfaces.cmake
@@ -254,6 +254,8 @@ if(BUILD_TESTING AND rosidl_generate_interfaces_ADD_LINTER_TESTS)
       TESTNAME "cpplint_rosidl_typesupport_connext_c"
       # the generated code might contain longer lines for templated types
       MAX_LINE_LENGTH 999
+      # the generated code might contain long functions without comments
+      FILTERS "-readability/fn_size"
       ROOT "${_cpplint_root}"
       ${_generated_files})
 

--- a/rosidl_typesupport_connext_cpp/cmake/rosidl_typesupport_connext_cpp_generate_interfaces.cmake
+++ b/rosidl_typesupport_connext_cpp/cmake/rosidl_typesupport_connext_cpp_generate_interfaces.cmake
@@ -252,6 +252,8 @@ if(BUILD_TESTING AND rosidl_generate_interfaces_ADD_LINTER_TESTS)
       TESTNAME "cpplint_rosidl_typesupport_connext_cpp"
       # the generated code might contain longer lines for templated types
       MAX_LINE_LENGTH 999
+      # the generated code might contain long functions without comments
+      FILTERS "-readability/fn_size"
       ROOT "${_cpplint_root}"
       ${_generated_files})
 


### PR DESCRIPTION
This lint error started manifesting itself with the introduction of new interfaces in https://github.com/ros2/test_interface_files/pull/3.

Connects to https://github.com/ros2/rcl_interfaces/issues/58