### PR TITLE
fix clang ignores

### DIFF
--- a/rosidl_typesupport_connext_cpp/src/wstring_conversion.cpp
+++ b/rosidl_typesupport_connext_cpp/src/wstring_conversion.cpp
@@ -14,7 +14,15 @@
 
 #include <rosidl_typesupport_connext_cpp/wstring_conversion.hpp>
 
+#ifdef __clang__
+# pragma clang diagnostic push
+# pragma clang diagnostic ignored "-Wdeprecated-register"
+# pragma clang diagnostic ignored "-Wreturn-type-c-linkage"
+#endif
 #include "ndds/ndds_cpp.h"
+#ifdef __clang__
+# pragma clang diagnostic pop
+#endif
 
 namespace rosidl_typesupport_connext_cpp
 {


### PR DESCRIPTION
Ignores these clang warnings: https://ci.ros2.org/job/ci_osx/5674/warnings11Result/

This patch uses the same pattern as in other locations (e.g. https://github.com/ros2/rosidl_typesupport_connext/pull/29/commits/43fccfd7f1dffec7b9ee07a9d7f3de96d26b82cf): [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_osx&build=5683)](https://ci.ros2.org/job/ci_osx/5683/)