### PR TITLE
make Connext 6 compatible

### DIFF
--- a/rosidl_typesupport_connext_c/include/rosidl_typesupport_connext_c/wstring_conversion.hpp
+++ b/rosidl_typesupport_connext_c/include/rosidl_typesupport_connext_c/wstring_conversion.hpp
@@ -15,11 +15,17 @@
 #ifndef ROSIDL_TYPESUPPORT_CONNEXT_C__WSTRING_CONVERSION_HPP_
 #define ROSIDL_TYPESUPPORT_CONNEXT_C__WSTRING_CONVERSION_HPP_
 
+#include "ndds/ndds_version.h"
+
 #include "rosidl_generator_c/u16string.h"
 #include "rosidl_typesupport_connext_c/visibility_control.h"
 
 // forward declare DDS_Wchar
+#if RTI_DDS_VERSION_MAJOR < 6
 typedef unsigned int DDS_Wchar;
+#else
+typedef unsigned short DDS_Wchar;  // NOLINT
+#endif
 
 namespace rosidl_typesupport_connext_c
 {

--- a/rosidl_typesupport_connext_c/src/wstring_conversion.cpp
+++ b/rosidl_typesupport_connext_c/src/wstring_conversion.cpp
@@ -14,14 +14,17 @@
 
 #include <rosidl_typesupport_connext_c/wstring_conversion.hpp>
 
-#ifdef __clang__
-# pragma clang diagnostic push
-# pragma clang diagnostic ignored "-Wdeprecated-register"
-# pragma clang diagnostic ignored "-Wreturn-type-c-linkage"
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wpedantic"
+# ifdef __clang__
+#  pragma clang diagnostic ignored "-Wdeprecated-register"
+#  pragma clang diagnostic ignored "-Wreturn-type-c-linkage"
+# endif
 #endif
 #include "ndds/ndds_c.h"
-#ifdef __clang__
-# pragma clang diagnostic pop
+#ifndef _WIN32
+# pragma GCC diagnostic pop
 #endif
 #include "rosidl_generator_c/u16string_functions.h"
 

--- a/rosidl_typesupport_connext_cpp/include/rosidl_typesupport_connext_cpp/wstring_conversion.hpp
+++ b/rosidl_typesupport_connext_cpp/include/rosidl_typesupport_connext_cpp/wstring_conversion.hpp
@@ -17,10 +17,16 @@
 
 #include <string>
 
+#include "ndds/ndds_version.h"
+
 #include "rosidl_typesupport_connext_cpp/visibility_control.h"
 
 // forward declare DDS_Wchar
+#if RTI_DDS_VERSION_MAJOR < 6
 typedef unsigned int DDS_Wchar;
+#else
+typedef unsigned short DDS_Wchar;  // NOLINT
+#endif
 
 namespace rosidl_typesupport_connext_cpp
 {

--- a/rosidl_typesupport_connext_cpp/src/wstring_conversion.cpp
+++ b/rosidl_typesupport_connext_cpp/src/wstring_conversion.cpp
@@ -14,14 +14,17 @@
 
 #include <rosidl_typesupport_connext_cpp/wstring_conversion.hpp>
 
-#ifdef __clang__
-# pragma clang diagnostic push
-# pragma clang diagnostic ignored "-Wdeprecated-register"
-# pragma clang diagnostic ignored "-Wreturn-type-c-linkage"
+#ifndef _WIN32
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wpedantic"
+# ifdef __clang__
+#  pragma clang diagnostic ignored "-Wdeprecated-register"
+#  pragma clang diagnostic ignored "-Wreturn-type-c-linkage"
+# endif
 #endif
 #include "ndds/ndds_cpp.h"
-#ifdef __clang__
-# pragma clang diagnostic pop
+#ifndef _WIN32
+# pragma GCC diagnostic pop
 #endif
 
 namespace rosidl_typesupport_connext_cpp


### PR DESCRIPTION
* Update `DDS_Wchar` typedef for Connext 6
* Suppress pedantic warnings within Connext 6 on Linux / macOS

CI builds only demonstrate that Connext 5 isn't negatively affected:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=8358)](http://ci.ros2.org/job/ci_linux/8358/) (`cpplint` warning addressed, assuming the other test failures are unrelated)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=6819)](http://ci.ros2.org/job/ci_osx/6819/) (failing on master with the same problems)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=8272)](http://ci.ros2.org/job/ci_windows/8272/) (assuming the other test failures are unrelated)