### PR TITLE
retry rtiddsgen(_server) invocation if it fails with a return code

### DIFF
--- a/rosidl_typesupport_connext_cpp/rosidl_typesupport_connext_cpp/__init__.py
+++ b/rosidl_typesupport_connext_cpp/rosidl_typesupport_connext_cpp/__init__.py
@@ -67,19 +67,31 @@ def generate_dds_connext_cpp(
         count = 1
         max_count = 5
         while True:
-            subprocess.check_call(cmd)
-
-            # fail safe if the generator does not work as expected
-            any_missing = False
-            for suffix in ['.h', '.cxx', 'Plugin.h', 'Plugin.cxx', 'Support.h', 'Support.cxx']:
-                filename = os.path.join(output_path, msg_name + suffix)
-                if not os.path.exists(filename):
-                    any_missing = True
+            try:
+                subprocess.check_call(cmd)
+            except subprocess.CalledProcessError as e:
+                # it seems that the RTI code generator sometimes fails
+                # when running in highly conconcurrent environments
+                # therefore we will just retry the invocation
+                print("'%s' failed for '%s/%s' with rc %d" %
+                      (idl_pp, pkg_name, msg_name, e.returncode),
+                      file=sys.stderr)
+                # just another double check since frequently the RTI code
+                # generator reports that the input .idl file is missing
+                assert os.path.exists(idl_file), \
+                    'Could not find IDL file: ' + idl_file
+            else:
+                # fail safe if the generator does not work as expected
+                any_missing = False
+                for suffix in ['.h', '.cxx', 'Plugin.h', 'Plugin.cxx', 'Support.h', 'Support.cxx']:
+                    filename = os.path.join(output_path, msg_name + suffix)
+                    if not os.path.exists(filename):
+                        any_missing = True
+                        break
+                if not any_missing:
                     break
-            if not any_missing:
-                break
-            print("'%s' failed to generate the expected files for '%s/%s'" %
-                  (idl_pp, pkg_name, msg_name), file=sys.stderr)
+                print("'%s' failed to generate the expected files for '%s/%s'" %
+                      (idl_pp, pkg_name, msg_name), file=sys.stderr)
             if count < max_count:
                 count += 1
                 print('Running code generator again (retry %d of %d)...' %

--- a/rosidl_typesupport_connext_cpp/rosidl_typesupport_connext_cpp/__init__.py
+++ b/rosidl_typesupport_connext_cpp/rosidl_typesupport_connext_cpp/__init__.py
@@ -70,9 +70,9 @@ def generate_dds_connext_cpp(
             try:
                 subprocess.check_call(cmd)
             except subprocess.CalledProcessError as e:
-                # it seems that the RTI code generator sometimes fails
-                # when running in highly conconcurrent environments
-                # therefore we will just retry the invocation
+                # HACK(dirk-thomas) it seems that the RTI code generator
+                # sometimes fails when running in highly conconcurrent
+                # environments therefore we will just retry the invocation
                 print("'%s' failed for '%s/%s' with rc %d" %
                       (idl_pp, pkg_name, msg_name, e.returncode),
                       file=sys.stderr)


### PR DESCRIPTION
When the buildfarm rebuilds the majority of the Debian packages of a ROS distro it frequently happens that packages containing messages fail to build.

The invocation of `rtiddsgen_server` returns with a non-zero code and the following error message (from http://build.ros2.org/view/Ebin_uB64/job/Ebin_uB64__action_msgs__ubuntu_bionic_amd64__binary/35/consoleFull):

> ERROR com.rti.ndds.nddsgen.Main Fail:  com.rti.ndds.nddsgen.Main$ArgumentException: File /tmp/binarydeb/ros-eloquent-action-msgs-0.8.0/obj-x86_64-linux-gnu/rosidl_generator_dds_idl/action_msgs/msg/dds_connext/GoalInfo_.idl doesn't exist. Please make sure that you have specified the correct path.

The logic already retries the invocation it finished with a rc 0 but didn't generate the desired files (https://github.com/ros2/rosidl_typesupport_connext/blob/2a56f0661e903fceca8f321ca5a09ebb04d8d146/rosidl_typesupport_connext_cpp/rosidl_typesupport_connext_cpp/__init__.py#L67-L88). But that doesn't seem to be the problem here. The command fails with a non-zero return code.

The logic already explicitly checks that the IDL file passed to the generator exists (https://github.com/ros2/rosidl_typesupport_connext/blob/2a56f0661e903fceca8f321ca5a09ebb04d8d146/rosidl_typesupport_connext_cpp/rosidl_typesupport_connext_cpp/__init__.py#L38) but the invocation still results in the above error message.

I can't reproduce the problem locally and newly triggered builds of the same job usually pass. So this patch is mostly an attempt to recover from this error condition and hopefully will make the binarydeb jobs pass reliably on the first attempt.

It could be a race deleting the IDL after the initial check (hence the new additional check after an invocation failed) but it is unclear why the file would be deleted. The other possibility is that the code generator fails for whatever other reason but reports a bogus error message...