### PR TITLE
code style only: wrap after open parenthesis if not in one line

### DIFF
--- a/rosidl_typesupport_connext_c/resource/msg__type_support_c.cpp.em
+++ b/rosidl_typesupport_connext_c/resource/msg__type_support_c.cpp.em
@@ -181,7 +181,8 @@ if isinstance(type_, AbstractNestedType):
 @[  if isinstance(type_, NamespacedType)]@
     const message_type_support_callbacks_t * @('__'.join(type_.namespaced_name()))__callbacks =
       static_cast<const message_type_support_callbacks_t *>(
-      ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_connext_c, @(', '.join(type_.namespaced_name()))
+      ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(
+        rosidl_typesupport_connext_c, @(', '.join(type_.namespaced_name()))
       )()->data);
 @[  end if]@
 @[  if isinstance(member.type, AbstractNestedType)]@


### PR DESCRIPTION
Style update to match the ROS 2 development guide and pass with the updated linter configuration from ament/ament_lint#210.