### PR TITLE
Ignore -Wclass-memaccess build warnings coming from Connext 5.3.1

### DIFF
--- a/connext_cmake_module/cmake/check_abi.cpp
+++ b/connext_cmake_module/cmake/check_abi.cpp
@@ -16,6 +16,7 @@
 
 #include <ndds/connext_cpp/connext_cpp_requester_details.h>
 
+#pragma GCC diagnostic ignored "-Wclass-memaccess"
 #pragma GCC diagnostic ignored "-Wuninitialized"
 
 int main(int, char **)

--- a/connext_cmake_module/cmake/check_abi.cpp
+++ b/connext_cmake_module/cmake/check_abi.cpp
@@ -16,7 +16,9 @@
 
 #include <ndds/connext_cpp/connext_cpp_requester_details.h>
 
-#pragma GCC diagnostic ignored "-Wclass-memaccess"
+#if __GNUC__ >= 9
+# pragma GCC diagnostic ignored "-Wclass-memaccess"
+#endif
 #pragma GCC diagnostic ignored "-Wuninitialized"
 
 int main(int, char **)

--- a/rosidl_typesupport_connext_c/resource/srv__type_support_c.cpp.em
+++ b/rosidl_typesupport_connext_c/resource/srv__type_support_c.cpp.em
@@ -33,6 +33,7 @@ dds_specific_header_files = [
 
 #ifndef _WIN32
 # pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wclass-memaccess"
 # pragma GCC diagnostic ignored "-Wunused-parameter"
 # ifdef __clang__
 #  pragma clang diagnostic ignored "-Wdeprecated-register"

--- a/rosidl_typesupport_connext_c/resource/srv__type_support_c.cpp.em
+++ b/rosidl_typesupport_connext_c/resource/srv__type_support_c.cpp.em
@@ -33,7 +33,9 @@ dds_specific_header_files = [
 
 #ifndef _WIN32
 # pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wclass-memaccess"
+# if __GNUC__ >= 9
+#  pragma GCC diagnostic ignored "-Wclass-memaccess"
+# endif
 # pragma GCC diagnostic ignored "-Wunused-parameter"
 # ifdef __clang__
 #  pragma clang diagnostic ignored "-Wdeprecated-register"

--- a/rosidl_typesupport_connext_cpp/resource/srv__type_support.cpp.em
+++ b/rosidl_typesupport_connext_cpp/resource/srv__type_support.cpp.em
@@ -30,6 +30,7 @@ dds_specific_header_files = [
 
 #ifndef _WIN32
 # pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wclass-memaccess"
 # pragma GCC diagnostic ignored "-Wunused-parameter"
 # ifdef __clang__
 #  pragma clang diagnostic ignored "-Wdeprecated-register"

--- a/rosidl_typesupport_connext_cpp/resource/srv__type_support.cpp.em
+++ b/rosidl_typesupport_connext_cpp/resource/srv__type_support.cpp.em
@@ -30,7 +30,9 @@ dds_specific_header_files = [
 
 #ifndef _WIN32
 # pragma GCC diagnostic push
-# pragma GCC diagnostic ignored "-Wclass-memaccess"
+# if __GNUC__ >= 9
+#  pragma GCC diagnostic ignored "-Wclass-memaccess"
+# endif
 # pragma GCC diagnostic ignored "-Wunused-parameter"
 # ifdef __clang__
 #  pragma clang diagnostic ignored "-Wdeprecated-register"


### PR DESCRIPTION
These warnings appear on Ubuntu Focal, e.g. http://build.ros2.org/view/Fci/job/Fci__nightly-connext_ubuntu_focal_amd64/50/warnings24Result/