### PR TITLE
Fix failure when find-pkging Connext Module and c/cxx languages aren't enabled

### DIFF
--- a/connext_cmake_module/cmake/Modules/FindConnext.cmake
+++ b/connext_cmake_module/cmake/Modules/FindConnext.cmake
@@ -323,13 +323,22 @@ if(Connext_FOUND)
       "${CMAKE_CURRENT_BINARY_DIR}/connext_cmake_module/check_abi/CMakeLists.txt"
       @ONLY
     )
-    try_compile(
-      Connext_GLIBCXX_USE_CXX11_ABI_ZERO
-      "${CMAKE_CURRENT_BINARY_DIR}/connext_cmake_module/check_abi/build"
-      "${CMAKE_CURRENT_BINARY_DIR}/connext_cmake_module/check_abi"
-      check_abi exe)
-    if(Connext_GLIBCXX_USE_CXX11_ABI_ZERO)
-      message(STATUS "Connext was build with an old libc++ ABI and needs _GLIBCXX_USE_CXX11_ABI 0")
+    get_property(_enabled_languages GLOBAL PROPERTY ENABLED_LANGUAGES)
+    list(FIND _enabled_languages "CXX" _is_cxx_language_enabled)
+    if(NOT "${_is_cxx_language_enabled}" EQUAL "-1")
+      try_compile(
+        Connext_GLIBCXX_USE_CXX11_ABI_ZERO
+        "${CMAKE_CURRENT_BINARY_DIR}/connext_cmake_module/check_abi/build"
+        "${CMAKE_CURRENT_BINARY_DIR}/connext_cmake_module/check_abi"
+        check_abi exe)
+      if(Connext_GLIBCXX_USE_CXX11_ABI_ZERO)
+        message(STATUS "Connext was build with an old libc++ ABI and needs _GLIBCXX_USE_CXX11_ABI 0")
+      endif()
+    else()
+      message(STATUS
+        "CMake project does not have CXX support enabled, "
+        "skipping Connext_GLIBCXX_USE_CXX11_ABI_ZERO check"
+      )
     endif()
   endif()
 endif()

--- a/connext_cmake_module/cmake/check_abi.cmake
+++ b/connext_cmake_module/cmake/check_abi.cmake
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 cmake_minimum_required(VERSION 2.8.3)
-project(connext_cmake_module_check_abi)
+project(connext_cmake_module_check_abi CXX)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic -Wl,--no-as-needed)


### PR DESCRIPTION
Fixes https://github.com/osrf/docker_images/issues/403.

We use Connext Module with two different purposes:

- Just check if Connext is available (e.g. [here](https://github.com/ros2/rosidl_typesupport_connext/blob/3787a9c209e2b29f2d2b56e834551188ae6cf4b3/rosidl_typesupport_connext_cpp/rosidl_typesupport_connext_cpp-extras.cmake.in#L4-L9)).
- Be able to compile/link against connext.

In the first case, variables like `Connext_GLIBCXX_USE_CXX11_ABI_ZERO` aren't of interest.

This PR does two changes:

- https://github.com/ros2/rosidl_typesupport_connext/commit/abbe78b9484daf0e1385823d7ca436f7b202b613 modifies the example project to only require CXX language. That already fixes https://github.com/osrf/docker_images/issues/403.
- https://github.com/ros2/rosidl_typesupport_connext/commit/e53473ac5124b0db07ead967640500335c01ea99 goes a bit further and avoids trying to set `Connext_GLIBCXX_USE_CXX11_ABI_ZERO` if the project that find-pkged Connext Module doesn't have CXX language support (in that case, setting `Connext_GLIBCXX_USE_CXX11_ABI_ZERO` is for sure not of interest).