### PR TITLE
remove pthread link flags for Android NDK cross-compiling

### DIFF
--- a/connext_cmake_module/cmake/Modules/FindConnext.cmake
+++ b/connext_cmake_module/cmake/Modules/FindConnext.cmake
@@ -311,7 +311,10 @@ endif()
 
 if(Connext_FOUND)
   if(NOT WIN32)
-    list(APPEND Connext_LIBRARIES "pthread" "dl")
+    if(NOT ANDROID)
+      list(APPEND Connext_LIBRARIES "pthread")
+    endif()
+    list(APPEND Connext_LIBRARIES "dl")
   endif()
 
   if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")


### PR DESCRIPTION
fix -lpthread leading Android NDK cross-compiling failed.

Signed-off-by: JayHou <houjie@lixiang.com>