### PR TITLE
fix capacity of serialized messages

### DIFF
--- a/rosidl_typesupport_connext_c/resource/msg__type_support_c.cpp.em
+++ b/rosidl_typesupport_connext_c/resource/msg__type_support_c.cpp.em
@@ -453,24 +453,31 @@ _@(message.structure.namespaced_type.name)__to_cdr_stream(
     fprintf(stderr, "failed to call @(__dds_cpp_msg_type_prefix)_Plugin_serialize_to_cdr_buffer()\n");
     return false;
   }
-  cdr_stream->buffer_length = expected_length;
-  if (cdr_stream->buffer_length > (std::numeric_limits<unsigned int>::max)()) {
-    fprintf(stderr, "cdr_stream->buffer_length, unexpectedly larger than max unsigned int\n");
+  if (expected_length > (std::numeric_limits<unsigned int>::max)()) {
+    fprintf(stderr, "expected_length, unexpectedly larger than max unsigned int\n");
     return false;
   }
-  if (cdr_stream->buffer_capacity < cdr_stream->buffer_length) {
+  if (cdr_stream->buffer_capacity < expected_length) {
+    uint8_t * new_buffer = static_cast<uint8_t *>(cdr_stream->allocator.allocate(expected_length, cdr_stream->allocator.state));
+    if (NULL == new_buffer) {
+      fprintf(stderr, "failed to allocate memory for cdr data\n");
+      return false;
+    }
     cdr_stream->allocator.deallocate(cdr_stream->buffer, cdr_stream->allocator.state);
-    cdr_stream->buffer = static_cast<uint8_t *>(cdr_stream->allocator.allocate(cdr_stream->buffer_length, cdr_stream->allocator.state));
+    cdr_stream->buffer = new_buffer;
+    cdr_stream->buffer_capacity = expected_length;
   }
   // call the function again and fill the buffer this time
-  unsigned int buffer_length_uint = static_cast<unsigned int>(cdr_stream->buffer_length);
+  unsigned int buffer_length_uint = static_cast<unsigned int>(expected_length);
   if (@(__dds_cpp_msg_type_prefix)_Plugin_serialize_to_cdr_buffer(
       reinterpret_cast<char *>(cdr_stream->buffer),
       &buffer_length_uint,
       &dds_message) != RTI_TRUE)
   {
+    cdr_stream->buffer_length = 0;
     return false;
   }
+  cdr_stream->buffer_length = expected_length;
 
   return true;
 }


### PR DESCRIPTION
Since the code was added originally in ros2/rmw_connext#259 the `buffer_capacity` of the `rcutils_uint8_array_t` wasn't updated after being reallocated. See http://build.ros2.org/view/Rci/job/Rci__nightly-connext_ubuntu_focal_amd64/29/testReport/rclcpp/TestSerializedMessage/serialization/ for a failing test because of that.

The patch is a bit more length since it makes sure to not partially modify the passed in `rcutils_uint8_array_t` when exiting with an error.