### PR TITLE
Check allocation of requester and replier

### DIFF
--- a/rosidl_typesupport_connext_cpp/resource/srv__type_support.cpp.em
+++ b/rosidl_typesupport_connext_cpp/resource/srv__type_support.cpp.em
@@ -151,6 +151,10 @@ void * create_requester__@(service.namespaced_type.name)(
   requester_params.datawriter_qos(*datawriter_qos);
 
   RequesterType * requester = static_cast<RequesterType *>(_allocator(sizeof(RequesterType)));
+  if (NULL == requester) {
+    fprintf(stderr, "failed to allocate memory for requester\n");
+    return NULL;
+  }
   try {
     new (requester) RequesterType(requester_params);
   } catch (...) {
@@ -255,6 +259,10 @@ void * create_replier__@(service.namespaced_type.name)(
   replier_params.datawriter_qos(*datawriter_qos);
 
   ReplierType * replier = static_cast<ReplierType *>(_allocator(sizeof(ReplierType)));
+  if (NULL == replier) {
+    fprintf(stderr, "failed to allocate memory for replier\n");
+    return NULL;
+  }
   try {
     new (replier) ReplierType(replier_params);
   } catch (...) {


### PR DESCRIPTION
This bug was found with the new fault injection tests in `rcl` (https://github.com/ros2/rcl/pull/727). If `_allocator` fails to allocate, there's an invalid read/write during the RequesterType constructor. The new rcl tests were only for the client, and not the service so the replier didn't have a similar segfault, but the issue still exists there too.

Fixes https://github.com/ros2/rcl/issues/767

Signed-off-by: Stephen Brawner <brawner@gmail.com>