### PR TITLE
Update cmake minimum version to 2.8.12

### DIFF
--- a/connext_cmake_module/cmake/check_abi.cmake
+++ b/connext_cmake_module/cmake/check_abi.cmake
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 2.8.12)
 project(connext_cmake_module_check_abi CXX)
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")


### PR DESCRIPTION
In the most recent release of cmake (3.19), they have started deprecating cmake versions < `2.8.12`. 

Example cmake warnings
https://ci.ros2.org/view/nightly/job/nightly_win_rel/1760/cmake/

Build all of ros2, testing up to `rcutils`
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=13157)](http://ci.ros2.org/job/ci_linux/13157/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=8088)](http://ci.ros2.org/job/ci_linux-aarch64/8088/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=10872)](http://ci.ros2.org/job/ci_osx/10872/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=13162)](http://ci.ros2.org/job/ci_windows/13162/)


Signed-off-by: Stephen Brawner <brawner@gmail.com>