### PR TITLE
Shorten some excessively long lines of CMake

### DIFF
--- a/connext_cmake_module/cmake/Modules/FindConnext.cmake
+++ b/connext_cmake_module/cmake/Modules/FindConnext.cmake
@@ -195,23 +195,33 @@ if(NOT _NDDSHOME STREQUAL "")
   _find_connext_libraries(_debug_libraries "${_debug_library_names}" "${_lib_path}")
 
   # check if all expected libraries have been found exactly once
-  _count_found_libraries(_optimized_libraries_count _found_all_optimized_libraries "${_optimized_library_names}" "${_optimized_libraries}")
-  _count_found_libraries(_debug_libraries_count _found_all_debug_libraries "${_debug_library_names}" "${_debug_libraries}")
+  _count_found_libraries(_optimized_libraries_count _found_all_optimized_libraries
+    "${_optimized_library_names}" "${_optimized_libraries}")
+  _count_found_libraries(_debug_libraries_count _found_all_debug_libraries
+    "${_debug_library_names}" "${_debug_libraries}")
 
   list(LENGTH _optimized_library_names _expected_length)
   if(_optimized_libraries_count GREATER _expected_length)
-    message(WARNING "NDDSHOME set to '${_NDDSHOME}' but found multiple files named '${_optimized_library_names}' under '${_lib_path}': ${_optimized_libraries}")
+    message(WARNING
+      "NDDSHOME set to '${_NDDSHOME}' but found multiple files named '${_optimized_library_names}' "
+      "under '${_lib_path}': ${_optimized_libraries}")
     set(_found_all_optimized_libraries FALSE)
   endif()
 
   list(LENGTH _debug_library_names _expected_length)
   if(_debug_libraries_count GREATER _expected_length)
-    message(WARNING "NDDSHOME set to '${_NDDSHOME}' but found multiple files named '${_debug_library_names}' under '${_lib_path}': ${_debug_libraries}")
+    message(WARNING
+      "NDDSHOME set to '${_NDDSHOME}' but found multiple files named '${_debug_library_names}' "
+      "under '${_lib_path}': ${_debug_libraries}")
     set(_found_all_debug_libraries FALSE)
   endif()
 
   if(NOT _found_all_optimized_libraries AND NOT _found_all_debug_libraries)
-    message(FATAL_ERROR "NDDSHOME set to '${_NDDSHOME}' but could neither find all optimized libraries '${_optimized_library_names}' nor all debug libraries '${_debug_library_names}' under '${_lib_path}':\n- optimized: ${_optimized_libraries}\n- debug: ${_debug_libraries}")
+    message(FATAL_ERROR
+      "NDDSHOME set to '${_NDDSHOME}' but could neither find all optimized libraries '${_optimized_library_names}' "
+      "nor all debug libraries '${_debug_library_names}' under '${_lib_path}':\n"
+      "- optimized: ${_optimized_libraries}\n"
+      "- debug: ${_debug_libraries}")
   endif()
 
   set(Connext_LIBRARIES "")
@@ -288,23 +298,29 @@ else()
     set(Connext_FOUND TRUE)
 
     # check if all expected libraries have been found exactly once
-    _count_found_libraries(_optimized_libraries_count _found_all_optimized_libraries "${_optimized_library_names}" "${Connext_LIBRARIES}")
-    _count_found_libraries(_debug_libraries_count _found_all_debug_libraries "${_debug_library_names}" "${Connext_LIBRARIES}")
+    _count_found_libraries(_optimized_libraries_count _found_all_optimized_libraries
+      "${_optimized_library_names}" "${Connext_LIBRARIES}")
+    _count_found_libraries(_debug_libraries_count _found_all_debug_libraries
+      "${_debug_library_names}" "${Connext_LIBRARIES}")
 
     list(LENGTH _optimized_library_names _expected_length)
     if(_optimized_libraries_count GREATER _expected_length)
-      message(WARNING "Found multiple files named '${_optimized_library_names}' in Connext_LIBRARIES: ${Connext_LIBRARIES}")
+      message(WARNING
+        "Found multiple files named '${_optimized_library_names}' in Connext_LIBRARIES: ${Connext_LIBRARIES}")
       set(_found_all_optimized_libraries FALSE)
     endif()
 
     list(LENGTH _debug_library_names _expected_length)
     if(_debug_libraries_count GREATER _expected_length)
-      message(WARNING "Found multiple files named '${_debug_library_names}' in Connext_LIBRARIES: ${Connext_LIBRARIES}")
+      message(WARNING
+        "Found multiple files named '${_debug_library_names}' in Connext_LIBRARIES: ${Connext_LIBRARIES}")
       set(_found_all_debug_libraries FALSE)
     endif()
 
     if(NOT _found_all_optimized_libraries AND NOT _found_all_debug_libraries)
-      message(FATAL_ERROR "Connext_LIBRARIES does neither contain all optimized libraries '${_optimized_library_names}' nor all debug libraries '${_debug_library_names}': ${Connext_LIBRARIES}")
+      message(FATAL_ERROR
+        "Connext_LIBRARIES does neither contain all optimized libraries '${_optimized_library_names}' "
+        "nor all debug libraries '${_debug_library_names}': ${Connext_LIBRARIES}")
     endif()
   endif()
 endif()


### PR DESCRIPTION
The line length enforcement in ament_lint_cmake has been broken for some time, but will be fixed by ament/ament_lint#236. This change brings this package into compliance with a 120 column limit.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=13667)](http://ci.ros2.org/job/ci_linux/13667/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=8546)](http://ci.ros2.org/job/ci_linux-aarch64/8546/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=11385)](http://ci.ros2.org/job/ci_osx/11385/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=13733)](http://ci.ros2.org/job/ci_windows/13733/)