### PR TITLE
Expose Connext C++ typesupport generation via rosidl generate CLI

### DIFF
--- a/rosidl_typesupport_connext_cpp/bin/rosidl_typesupport_connext_cpp
+++ b/rosidl_typesupport_connext_cpp/bin/rosidl_typesupport_connext_cpp
@@ -28,9 +28,8 @@ def main(argv=sys.argv[1:]):
 
     generator_args = read_generator_arguments(args.generator_arguments_file)
 
-    rc = generate_cpp(args.generator_arguments_file)
-    if rc:
-        return rc
+    generate_cpp(args.generator_arguments_file)
+
     return generate_dds_connext_cpp(
         generator_args['package_name'],
         generator_args.get('additional_files', []),

--- a/rosidl_typesupport_connext_cpp/package.xml
+++ b/rosidl_typesupport_connext_cpp/package.xml
@@ -26,6 +26,7 @@
 
   <build_export_depend>rmw</build_export_depend>
 
+  <exec_depend>ament_index_python</exec_depend>
   <exec_depend>rosidl_cli</exec_depend>
   <exec_depend>rosidl_parser</exec_depend>
   <exec_depend>rosidl_typesupport_interface</exec_depend>

--- a/rosidl_typesupport_connext_cpp/package.xml
+++ b/rosidl_typesupport_connext_cpp/package.xml
@@ -26,6 +26,7 @@
 
   <build_export_depend>rmw</build_export_depend>
 
+  <exec_depend>rosidl_cli</exec_depend>
   <exec_depend>rosidl_parser</exec_depend>
   <exec_depend>rosidl_typesupport_interface</exec_depend>
 

--- a/rosidl_typesupport_connext_cpp/rosidl_typesupport_connext_cpp/__init__.py
+++ b/rosidl_typesupport_connext_cpp/rosidl_typesupport_connext_cpp/__init__.py
@@ -18,6 +18,7 @@ import sys
 
 from rosidl_cmake import generate_files
 
+
 def generate_dds_connext_cpp_file(
     package_name, idl_file, include_dirs, output_path, idl_pp
 ):

--- a/rosidl_typesupport_connext_cpp/rosidl_typesupport_connext_cpp/__init__.py
+++ b/rosidl_typesupport_connext_cpp/rosidl_typesupport_connext_cpp/__init__.py
@@ -18,6 +18,75 @@ import sys
 
 from rosidl_cmake import generate_files
 
+def generate_dds_connext_cpp_file(
+    package_name, idl_file, include_dirs, output_path, idl_pp
+):
+    cmd = [idl_pp]
+    for include_dir in include_dirs:
+        cmd += ['-I', include_dir]
+    cmd += [
+        '-d', output_path,
+        '-language', 'C++',
+        '-namespace',
+        '-update', 'typefiles',
+        '-unboundedSupport',
+        idl_file
+    ]
+    if os.name == 'nt':
+        cmd[-5:-5] = ['-dllExportMacroSuffix', package_name]
+
+    msg_name = os.path.splitext(os.path.basename(idl_file))[0]
+    count = 1
+    max_count = 5
+    while True:
+        try:
+            subprocess.check_call(cmd)
+        except subprocess.CalledProcessError as e:
+            # HACK(dirk-thomas) it seems that the RTI code generator
+            # sometimes fails when running in highly conconcurrent
+            # environments using the server mode
+            # therefore we will retry in non-server mode
+            print("'%s' failed for '%s/%s' with rc %d" %
+                  (idl_pp, package_name, msg_name, e.returncode),
+                  file=sys.stderr)
+            dirname, basename = os.path.split(cmd[0])
+            root, ext = os.path.splitext(basename)
+            server_suffix = '_server'
+            if not root.endswith(server_suffix):
+                raise
+            print('Running non-server code generator instead...',
+                  file=sys.stderr)
+            cmd[0] = os.path.join(dirname, root[:-len(server_suffix)] + ext)
+            subprocess.check_call(cmd)
+
+        # fail safe if the generator does not work as expected
+        any_missing = False
+        generated_files = []
+        for suffix in ['.h', '.cxx', 'Plugin.h', 'Plugin.cxx', 'Support.h', 'Support.cxx']:
+            filename = os.path.join(output_path, msg_name + suffix)
+            if not os.path.exists(filename):
+                any_missing = True
+                break
+            generated_files.append(filename)
+        if not any_missing:
+            break
+        print("'%s' failed to generate the expected files for '%s/%s'" %
+              (idl_pp, package_name, msg_name), file=sys.stderr)
+        if count < max_count:
+            count += 1
+            print('Running code generator again (retry %d of %d)...' %
+                  (count, max_count), file=sys.stderr)
+            continue
+        raise RuntimeError('failed to generate the expected files')
+
+    if os.name != 'nt':
+        # modify generated code to avoid unsed global variable warning
+        # which can't be suppressed non-globally with gcc
+        msg_filename = os.path.join(output_path, msg_name + '.h')
+        _modify(msg_filename, package_name, msg_name, _inject_unused_attribute)
+
+    return generated_files
+
 
 def generate_dds_connext_cpp(
         pkg_name, dds_interface_files, dds_interface_base_path, deps,
@@ -49,67 +118,8 @@ def generate_dds_connext_cpp(
         except FileExistsError:
             pass
 
-        cmd = [idl_pp]
-        for include_dir in include_dirs:
-            cmd += ['-I', include_dir]
-        cmd += [
-            '-d', output_path,
-            '-language', 'C++',
-            '-namespace',
-            '-update', 'typefiles',
-            '-unboundedSupport',
-            idl_file
-        ]
-        if os.name == 'nt':
-            cmd[-5:-5] = ['-dllExportMacroSuffix', pkg_name]
-
-        msg_name = os.path.splitext(os.path.basename(idl_file))[0]
-        count = 1
-        max_count = 5
-        while True:
-            try:
-                subprocess.check_call(cmd)
-            except subprocess.CalledProcessError as e:
-                # HACK(dirk-thomas) it seems that the RTI code generator
-                # sometimes fails when running in highly conconcurrent
-                # environments using the server mode
-                # therefore we will retry in non-server mode
-                print("'%s' failed for '%s/%s' with rc %d" %
-                      (idl_pp, pkg_name, msg_name, e.returncode),
-                      file=sys.stderr)
-                dirname, basename = os.path.split(cmd[0])
-                root, ext = os.path.splitext(basename)
-                server_suffix = '_server'
-                if not root.endswith(server_suffix):
-                    raise
-                print('Running non-server code generator instead...',
-                      file=sys.stderr)
-                cmd[0] = os.path.join(dirname, root[:-len(server_suffix)] + ext)
-                subprocess.check_call(cmd)
-
-            # fail safe if the generator does not work as expected
-            any_missing = False
-            for suffix in ['.h', '.cxx', 'Plugin.h', 'Plugin.cxx', 'Support.h', 'Support.cxx']:
-                filename = os.path.join(output_path, msg_name + suffix)
-                if not os.path.exists(filename):
-                    any_missing = True
-                    break
-            if not any_missing:
-                break
-            print("'%s' failed to generate the expected files for '%s/%s'" %
-                  (idl_pp, pkg_name, msg_name), file=sys.stderr)
-            if count < max_count:
-                count += 1
-                print('Running code generator again (retry %d of %d)...' %
-                      (count, max_count), file=sys.stderr)
-                continue
-            raise RuntimeError('failed to generate the expected files')
-
-        if os.name != 'nt':
-            # modify generated code to avoid unsed global variable warning
-            # which can't be suppressed non-globally with gcc
-            msg_filename = os.path.join(output_path, msg_name + '.h')
-            _modify(msg_filename, pkg_name, msg_name, _inject_unused_attribute)
+        generate_dds_connext_cpp_file(
+            pkg_name, idl_file, include_dirs, output_path, idl_pp)
 
     return 0
 
@@ -141,5 +151,4 @@ def generate_cpp(arguments_file):
         'idl__dds_connext__type_support.cpp.em':
         'dds_connext/%s__type_support.cpp'
     }
-    generate_files(arguments_file, mapping)
-    return 0
+    return generate_files(arguments_file, mapping)

--- a/rosidl_typesupport_connext_cpp/rosidl_typesupport_connext_cpp/cli.py
+++ b/rosidl_typesupport_connext_cpp/rosidl_typesupport_connext_cpp/cli.py
@@ -1,0 +1,157 @@
+# Copyright 2021 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import pathlib
+import subprocess
+
+from ament_index_python import get_package_share_directory
+
+from rosidl_cli.command.generate.extensions import GenerateCommandExtension
+from rosidl_cli.command.helpers import generate_visibility_control_file
+from rosidl_cli.command.helpers import legacy_generator_arguments_file
+from rosidl_cli.command.helpers import idl_tuples_from_interface_files
+from rosidl_cli.command.translate.api import translate
+
+from rosidl_typesupport_connext_cpp import generate_cpp
+from rosidl_typesupport_connext_cpp import generate_dds_connext_cpp_file
+
+
+def find_rti_connext_idl_preprocessor():
+    if os.name == 'nt':
+        if 'NDDSHOME' not in os.environ:
+            raise RuntimeError('"NDDSHOME" not set')
+        nddshome = os.environ['NDDSHOME']
+        ddsgen = os.path.join(nddshome, 'bin', 'rtiddsgen.bat')
+        ddsgen_server = os.path.join(nddshome, 'bin', 'rtiddsgen_server.bat')
+    else:
+        nddshome = os.environ.get('NDDSHOME', '/usr')
+        ddsgen = os.path.join(nddshome, 'bin', 'rtiddsgen')
+        ddsgen_server = os.path.join(nddshome, 'bin', 'rtiddsgen_server')
+    if os.path.exists(ddsgen_server):
+        proc = subprocess.run([ddsgen_server, '-n_version'])
+        if proc.returncode == 0:
+            return ddsgen_server
+    if not os.path.exists(ddsgen):
+        raise RuntimeError(f'{ddsgen} could not be found')
+    return ddsgen
+
+
+class GenerateDDSConnextCpp(GenerateCommandExtension):
+
+    def generate(
+        self,
+        package_name,
+        interface_files,
+        include_paths,
+        output_path
+    ):
+        idl_pp = find_rti_connext_idl_preprocessor()
+
+        # Normalize interface definition format to _.idl
+        dds_idl_interface_files = []
+        non_dds_idl_interface_files = []
+        for path in interface_files:
+            if not path.endswith('_.idl'):
+                non_dds_idl_interface_files.append(path)
+            else:
+                dds_idl_interface_files.append(path)
+        if non_dds_idl_interface_files:
+            dds_idl_interface_files.extend(translate(
+                package_name=package_name,
+                interface_files=non_dds_idl_interface_files,
+                include_paths=include_paths,
+                output_format='dds_idl',
+                output_path=output_path / 'tmp',
+            ))
+
+        generated_files = []
+        for idl_tuple in idl_tuples_from_interface_files(
+            dds_idl_interface_files
+        ):
+            prefix, _, stem = idl_tuple.rpartition(':')
+            idl_file = os.path.join(prefix, stem)
+
+            output_dir = os.path.join(
+                output_path, os.path.dirname(stem))
+            os.makedirs(output_dir, exist_ok=True)
+
+            # Generate RTI Connext specific code
+            generated_files.extend(generate_dds_connext_cpp_file(
+                package_name, idl_file, include_paths, output_dir, idl_pp
+            ))
+
+        return generated_files
+
+
+class GenerateConnextCppTypesupport(GenerateCommandExtension):
+
+    def generate(
+        self,
+        package_name,
+        interface_files,
+        include_paths,
+        output_path
+    ):
+        generated_files = []
+
+        package_share_path = pathlib.Path(
+            get_package_share_directory('rosidl_typesupport_connext_cpp'))
+        templates_path = package_share_path / 'resource'
+
+        # Normalize interface definition format to .idl
+        idl_interface_files = []
+        non_idl_interface_files = []
+        for path in interface_files:
+            if not path.endswith('.idl'):
+                non_idl_interface_files.append(path)
+            else:
+                idl_interface_files.append(path)
+        if non_idl_interface_files:
+            idl_interface_files.extend(translate(
+                package_name=package_name,
+                interface_files=non_idl_interface_files,
+                include_paths=include_paths,
+                output_format='idl',
+                output_path=output_path / 'tmp',
+            ))
+
+        # Generate visibility control file
+        visibility_control_file_template_path = \
+            'rosidl_typesupport_connext_cpp__visibility_control.h.in'
+        visibility_control_file_template_path = \
+            templates_path / visibility_control_file_template_path
+        visibility_control_file_path = \
+            'rosidl_typesupport_connext_cpp__visibility_control.h'
+        visibility_control_file_path = \
+            output_path / 'msg' / visibility_control_file_path
+
+        generate_visibility_control_file(
+            package_name=package_name,
+            template_path=visibility_control_file_template_path,
+            output_path=visibility_control_file_path
+        )
+        generated_files.append(visibility_control_file_path)
+
+        with legacy_generator_arguments_file(
+            package_name=package_name,
+            interface_files=idl_interface_files,
+            include_paths=include_paths,
+            templates_path=templates_path,
+            output_path=output_path
+        ) as path_to_arguments_file:
+            # Generate typesupport code
+            generated_files.extend(generate_cpp(path_to_arguments_file))
+
+        return generated_files

--- a/rosidl_typesupport_connext_cpp/rosidl_typesupport_connext_cpp/cli.py
+++ b/rosidl_typesupport_connext_cpp/rosidl_typesupport_connext_cpp/cli.py
@@ -20,8 +20,8 @@ from ament_index_python import get_package_share_directory
 
 from rosidl_cli.command.generate.extensions import GenerateCommandExtension
 from rosidl_cli.command.helpers import generate_visibility_control_file
-from rosidl_cli.command.helpers import legacy_generator_arguments_file
 from rosidl_cli.command.helpers import idl_tuples_from_interface_files
+from rosidl_cli.command.helpers import legacy_generator_arguments_file
 from rosidl_cli.command.translate.api import translate
 
 from rosidl_typesupport_connext_cpp import generate_cpp

--- a/rosidl_typesupport_connext_cpp/setup.cfg
+++ b/rosidl_typesupport_connext_cpp/setup.cfg
@@ -1,0 +1,5 @@
+[options.entry_points]
+rosidl_cli.command.generate.type_extensions =
+  dds_connext_cpp = rosidl_typesupport_connext_cpp.cli:GenerateDDSConnextCpp
+rosidl_cli.command.generate.typesupport_extensions =
+  connext_cpp = rosidl_typesupport_connext_cpp.cli:GenerateConnextCppTypesupport


### PR DESCRIPTION
Generation is split in two distinct steps:

- A type extension plugin that wraps Connext C++ code generation
- A typesupport extension plugin compatible with Connext C++ RMWs that depends on the former and on plain C++ type generation

This allows the necessary translation from ROS `.idl` files to DDS `.idl` files to be carried out and subsequently cached by a calling build system.